### PR TITLE
Add settings schema and extend specs for v0.2.0 user preferences

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -70,3 +70,6 @@ paths:
                 $ref: './dto/popup-state.schema.json'
 components:
   securitySchemes: {}
+  schemas:
+    UserSettings:
+      $ref: './settings.schema.json'

--- a/contracts/settings.schema.json
+++ b/contracts/settings.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codex.tasks/contracts/settings.schema.json",
+  "title": "CodexTasksUserSettings",
+  "description": "Пользовательские настройки расширения, синхронизируемые через chrome.storage.sync (v0.2.0+)",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "debounceMs": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 60000,
+      "default": 12000,
+      "description": "Продолжительность окна антидребезга в миллисекундах"
+    },
+    "sound": {
+      "type": "boolean",
+      "default": false,
+      "description": "Воспроизводить ли звуковое уведомление при завершении задач"
+    },
+    "autoDiscardableOff": {
+      "type": "boolean",
+      "default": true,
+      "description": "Отключает авто-выгрузку вкладок Codex через chrome.tabs.update({ autoDiscardable: false })"
+    },
+    "showBadgeCount": {
+      "type": "boolean",
+      "default": true,
+      "description": "Отображать ли количество активных задач на бейдже иконки расширения"
+    }
+  }
+}

--- a/spec/implementation-plan.md
+++ b/spec/implementation-plan.md
@@ -39,6 +39,7 @@
    - Модуль `notifications` контролирует антидребезг, создаёт уведомления.
    - Модуль `alarms` управляет `chrome.alarms`, пингует вкладки.
    - Хендлер `tabs.onRemoved` поддерживает консистентность состояния.
+   - (v0.2.0+) Модуль `settings` валидирует объект по `contracts/settings.schema.json`, синхронизирует `chrome.storage.sync`, применяет `debounceMs`, `autoDiscardableOff`, `sound`, `showBadgeCount`.
 4. **Popup**
    - Простое отображение списка вкладок: использование HTMX/VanillaJS + шаблонов.
    - Запрос состояния через messaging (адаптер реализует вызов `/popup/state`).
@@ -66,3 +67,8 @@
 - Все Acceptance Criteria из `spec/test-plan.md` выполнены автоматизированными тестами.
 - Manifest проходит проверку Chrome Web Store без предупреждений.
 - README дополнено инструкцией по сборке и установке unpacked расширения.
+
+## Дополнительно для релиза v0.2.0
+- Реализованы UI/опции для редактирования настроек `CodexTasksUserSettings`.
+- Background синхронизирует и валидирует настройки, применяет `autoDiscardableOff`, `debounceMs`, `sound`, `showBadgeCount` ко всем открытым вкладкам.
+- Покрытие тестами сценариев изменения настроек и их влияния на уведомления, бейдж и autoDiscardable.

--- a/spec/test-plan.md
+++ b/spec/test-plan.md
@@ -4,6 +4,7 @@
 - Подтвердить соответствие контент-скрипта и background спецификациям JSON Schema.
 - Проверить корректность антидребезга и уникальность уведомлений.
 - Убедиться, что popup отображает актуальное состояние задач.
+- Для релизов v0.2.0+: подтвердить управление пользовательскими настройками и их применение.
 
 ## Область покрытия
 - Юнит-тесты детекторов и агрегатора.
@@ -31,20 +32,25 @@
    - Given вкладка с `count>0` закрывается (без финального сообщения),
    - When background получает событие `tabs.onRemoved`,
    - Then состояние вкладки удаляется, `lastTotal` пересчитывается, уведомление не создаётся, если есть другие активные задачи.
+6. **AC6 — Синхронизация пользовательских настроек (v0.2.0+)**
+   - Given в `chrome.storage.sync.settings` записаны значения по схеме `CodexTasksUserSettings`,
+   - When пользователь изменяет `debounceMs`, `autoDiscardableOff`, `sound` или `showBadgeCount` через UI,
+   - Then background валидирует объект, обновляет `AggregatedState.debounce.ms`, применяет `autoDiscardable` к вкладкам и синхронно обновляет бейдж и звуковой режим.
 
 ## Типы тестов
 - **Unit**
   - Детекторы: корректное определение активности по тестовым DOM-фрагментам.
   - Агрегатор: переходы состояний `lastTotal`, антидребезг.
+  - Settings: валидация объекта настроек, применение дефолтов и пересчёт `debounceMs`.
 - **Contract**
   - Валидация OpenAPI: `POST /background/tasks-update`, `GET /background/state`, `GET /popup/state`.
-  - JSON Schema: сериализация `AggregatedState` и `PopupRenderState`.
+  - JSON Schema: сериализация `AggregatedState`, `PopupRenderState` и `CodexTasksUserSettings`.
 - **Integration**
-  - Симуляция Chrome APIs (tabs, alarms, notifications) через фейки. Проверка сценариев UC-1..UC-4.
+  - Симуляция Chrome APIs (tabs, alarms, notifications, storage.sync) через фейки. Проверка сценариев UC-1..UC-4 и изменения настроек.
 
 ## Тестовые данные
 - DOM-фрагменты для детекторов D1/D2/D3 на RU/EN интерфейсах.
-- Моки Chrome API: `tabs.query`, `notifications.create`, `storage.session`.
+- Моки Chrome API: `tabs.query`, `notifications.create`, `storage.session`, `storage.sync`.
 - Набор последовательностей сообщений для воспроизведения сценариев (см. `spec/use-cases.md`).
 
 ## Метрики и отчётность


### PR DESCRIPTION
## Summary
- add contracts/settings.schema.json describing debounceMs, sound, autoDiscardableOff and showBadgeCount constraints per brief
- reference the new schema from openapi.yaml for contract visibility
- extend system-capabilities, implementation-plan and test-plan specs with v0.2.0 settings behavior

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e19c3b5694833294a114fefce1db14