### PR TITLE
Обновить описание контракта ContentScriptTasksUpdate в roadmap

### DIFF
--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -58,7 +58,7 @@
 
 - [ ] **Бутстрап и обмен сообщениями**
   - [ ] Создать точку входа `src/content/index.ts`, которая инициализирует детекторы, подписки и логирование (reuse shared logger).
-  - [ ] Зафиксировать контракт `ContentMessage` и подготовить helper-функции (`postToBackground`, `onBackgroundEvent`).
+  - [ ] Зафиксировать контракт `ContentScriptTasksUpdate` и подготовить helper-функции (`postToBackground`, `onBackgroundEvent`), работающие с сообщением `TASKS_UPDATE` из `contracts/dto/content-update.schema.json`.
 - [ ] **Модульная система детекторов**
   - [ ] Реализовать интерфейс `Detector` c методами `bootstrap`, `scan`, `teardown`, обеспечив смену локали без перезагрузки.
   - [ ] Внедрить детекторы D1 (spinner) и D2 (Stop button) с DOM-фикстурами и unit-тестами для RU/EN.


### PR DESCRIPTION
## Summary
- скорректировал пункт фазы 2 дорожной карты, переименовав контракт в ContentScriptTasksUpdate и уточнив работу helper-функций с сообщением TASKS_UPDATE из актуальной схемы

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e36d746f0c83328d166cb27687dac5