### PR TITLE
Clarify heartbeat recovery acceptance criteria

### DIFF
--- a/spec/test-plan.md
+++ b/spec/test-plan.md
@@ -39,14 +39,14 @@
 7. **AC7 — Обнаружение и восстановление heartbeat**
    - Given вкладка перестала отправлять `TASKS_HEARTBEAT` на 45 секунд,
    - When alarm `codex-poll` срабатывает и отправляет `PING`, контент-скрипт отвечает `TASKS_UPDATE` + `TASKS_HEARTBEAT`,
-   - Then background обновляет `tabs[tabId].heartbeat.lastSeenAt`, ставит статус `OK`, сбрасывает `missedCount` и сразу возвращает вкладку в агрегированное состояние «жива».
+   - Then background сразу после получения `TASKS_HEARTBEAT` обновляет `tabs[tabId].heartbeat.lastSeenAt`, сбрасывает `missedCount`, переводит статус в `OK` и возвращает вкладку в агрегированное состояние «жива».
 
 ## Типы тестов
 - **Unit**
   - Детекторы: корректное определение активности по тестовым DOM-фрагментам.
   - Агрегатор: переходы состояний `lastTotal`, антидребезг и применение формулы `max(D2_count, D3_count, D1_indicatorCount)` (включая сценарий «только D3»).
   - Settings: валидация объекта настроек, применение дефолтов и пересчёт `debounceMs`.
-  - Heartbeat: обработка `TASKS_HEARTBEAT`, обновление `lastSeenAt`, логика `missedCount` и статуса `STALE` → `OK`.
+  - Heartbeat: обработка `TASKS_HEARTBEAT` с немедленным обновлением `lastSeenAt`, сбросом `missedCount` и переходом статуса `STALE` → `OK`.
 - **Contract**
   - Валидация OpenAPI: `POST /background/tasks-update`, `POST /background/tasks-heartbeat`, `GET /background/state`, `GET /popup/state`.
   - JSON Schema: сериализация `AggregatedState`, `PopupRenderState` и `CodexTasksUserSettings`.


### PR DESCRIPTION
## Цель
- Уточнить критерии приемки для сценария восстановления heartbeat и привести тест-план к формулировкам UC-5.

## Ссылка на спецификацию / ADR
- `spec/use-cases.md#uc-5-потеря-heartbeat-и-автоматическое-восстановление`

## Влияние на API/данные
- Нет изменений API или данных, обновлена документация тест-плана.

## Риски
- Низкие: правки только в описательной документации.

## План отката
- Вернуть предыдущую версию `spec/test-plan.md`.


------
https://chatgpt.com/codex/tasks/task_e_68e3a3fabff483328a8e43d5ada4342c