### PR TITLE
Синхронизировать бриф и схемы TASKS_UPDATE/heartbeat

### DIFF
--- a/contracts/dto/content-update.schema.json
+++ b/contracts/dto/content-update.schema.json
@@ -9,7 +9,8 @@
     "origin",
     "active",
     "count",
-    "signals"
+    "signals",
+    "ts"
   ],
   "properties": {
     "type": {

--- a/spec/test-plan.md
+++ b/spec/test-plan.md
@@ -39,7 +39,7 @@
 7. **AC7 — Обнаружение и восстановление heartbeat**
    - Given вкладка перестала отправлять `TASKS_HEARTBEAT` на 45 секунд,
    - When alarm `codex-poll` срабатывает и отправляет `PING`, контент-скрипт отвечает `TASKS_UPDATE` + `TASKS_HEARTBEAT`,
-   - Then background сразу после получения `TASKS_HEARTBEAT` обновляет `tabs[tabId].heartbeat.lastSeenAt`, сбрасывает `missedCount`, переводит статус в `OK` и возвращает вкладку в агрегированное состояние «жива».
+   - Then background сразу после получения `TASKS_HEARTBEAT` обновляет `tabs[tabId].lastSeenAt` и `tabs[tabId].heartbeat.lastReceivedAt`, сбрасывает `missedCount`, переводит статус в `OK` и возвращает вкладку в агрегированное состояние «жива».
 
 ## Типы тестов
 - **Unit**


### PR DESCRIPTION
## Summary
- отметили `ts` обязательным полем в схеме `TASKS_UPDATE` и синхронизировали описание в брифе
- уточнили бриф: инициализация heartbeat и `lastSeenAt` при первом сообщении вкладки, обновили псевдокод background
- поправили AC7 в тест-плане для корректных путей обновления heartbeat

## Testing
- not run (docs-only)


------
https://chatgpt.com/codex/tasks/task_e_68e3d3c4c2c08332a0d68616220f7247