### PR TITLE
Implement background service worker core

### DIFF
--- a/extension/src/background/alarms.ts
+++ b/extension/src/background/alarms.ts
@@ -1,12 +1,107 @@
-/**
- * Placeholder for chrome.alarms coordination. The actual scheduling strategy is
- * defined in `spec/system-capabilities.md` and `spec/nfr.md` (heartbeat <= 15s,
- * alarm ping interval, recovery from service worker sleep).
- */
+import {
+  createChildLogger,
+  createLogger,
+  resolveChrome,
+  type AlarmListener,
+  type ChromeLike,
+  type ChromeLogger,
+} from '../shared/chrome';
+import type { AggregatedTabsState } from '../shared/contracts';
+import type { BackgroundAggregator } from './aggregator';
 
-export function registerAlarms(): void {
-  if (import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
-    console.debug('[codex-tasks-watcher] alarms placeholder registered');
+const ALARM_NAME = 'codex-poll';
+const ALARM_PERIOD_MINUTES = 1;
+
+export interface AlarmsOptions {
+  readonly chrome?: ChromeLike;
+  readonly logger?: ChromeLogger;
+}
+
+export interface AlarmsController {
+  dispose(): void;
+}
+
+export function registerAlarms(
+  aggregator: BackgroundAggregator,
+  options: AlarmsOptions = {},
+): AlarmsController {
+  const chrome = options.chrome ?? resolveChrome();
+  const baseLogger = options.logger ?? createLogger('codex-background');
+  const logger = createChildLogger(baseLogger, 'alarms');
+
+  chrome.alarms.create(ALARM_NAME, { periodInMinutes: ALARM_PERIOD_MINUTES });
+  logger.info('alarm scheduled', { name: ALARM_NAME, periodMinutes: ALARM_PERIOD_MINUTES });
+
+  const protectedTabs = new Set<number>();
+
+  const unsubscribe = aggregator.onStateChange((event) => {
+    void ensureAutoDiscardable(event.current).catch((error) => {
+      logger.warn('failed to enforce autoDiscardable', error);
+    });
+    if (event.reason === 'tab-removed' && typeof event.tabId === 'number') {
+      protectedTabs.delete(event.tabId);
+    }
+  });
+
+  void aggregator.ready
+    .then(() => aggregator.getSnapshot())
+    .then((snapshot) => ensureAutoDiscardable(snapshot))
+    .catch((error) => {
+      logger.error('failed to apply autoDiscardable on startup', error);
+    });
+
+  const alarmListener: AlarmListener = (alarm) => {
+    if (alarm.name !== ALARM_NAME) {
+      return;
+    }
+    void handleAlarmTick().catch((error) => {
+      logger.error('alarm tick failed', error);
+    });
+  };
+
+  chrome.alarms.onAlarm.addListener(alarmListener);
+
+  return {
+    dispose() {
+      chrome.alarms.onAlarm.removeListener(alarmListener);
+      unsubscribe();
+      protectedTabs.clear();
+    },
+  };
+
+  async function ensureAutoDiscardable(state: AggregatedTabsState): Promise<void> {
+    for (const tabId of Object.keys(state.tabs).map(Number)) {
+      if (protectedTabs.has(tabId)) {
+        continue;
+      }
+      try {
+        await chrome.tabs.update(tabId, { autoDiscardable: false });
+        protectedTabs.add(tabId);
+        logger.debug('autoDiscardable disabled', { tabId });
+      } catch (error) {
+        logger.warn('autoDiscardable update failed', { tabId, error });
+      }
+    }
+    for (const tabId of Array.from(protectedTabs)) {
+      if (!state.tabs[String(tabId)]) {
+        protectedTabs.delete(tabId);
+      }
+    }
+  }
+
+  async function handleAlarmTick(): Promise<void> {
+    logger.debug('alarm tick');
+    const staleTabIds = await aggregator.evaluateHeartbeatStatuses();
+    if (staleTabIds.length === 0) {
+      return;
+    }
+    for (const tabId of staleTabIds) {
+      try {
+        await chrome.tabs.sendMessage(tabId, { type: 'PING' });
+        logger.info('ping sent to tab', { tabId });
+      } catch (error) {
+        logger.warn('failed to ping tab', { tabId, error });
+      }
+    }
   }
 }

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -1,27 +1,125 @@
-/**
- * Entry point for the background service worker. Real listeners will be implemented in later
- * roadmap phases. The current implementation keeps the bundle valid and establishes the module
- * boundaries referenced by the specification.
- */
-
-  
-import { initializeAggregator } from './aggregator';
-import { initializeNotifications } from './notifications';
+import {
+  assertContentScriptHeartbeat,
+  assertContentScriptTasksUpdate,
+} from '../shared/contracts';
+import {
+  createChildLogger,
+  createLogger,
+  resolveChrome,
+  type ChromeLike,
+  type ChromeLogger,
+} from '../shared/chrome';
+import { initializeAggregator, type BackgroundAggregator } from './aggregator';
 import { registerAlarms } from './alarms';
+import { initializeNotifications } from './notifications';
 
-function bootstrapBackground(): void {
-  initializeAggregator();
-  initializeNotifications();
-  registerAlarms();
+const VERBOSE_KEY = 'codex.tasks.verbose';
 
-  if (import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
-    console.debug('[codex-tasks-watcher] background bootstrap placeholder');
+const chrome = resolveChrome();
+const { logger: rootLogger } = createVerbosityAwareLogger(chrome);
+const aggregator = initializeAggregator({ chrome, logger: rootLogger });
+
+initializeNotifications(aggregator, { chrome, logger: rootLogger });
+registerAlarms(aggregator, { chrome, logger: rootLogger });
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  handleRuntimeMessage(aggregator, createChildLogger(rootLogger, 'runtime'), message, sender)
+    .catch((error) => {
+      rootLogger.error('message handling failed', error);
+    })
+    .finally(() => {
+      try {
+        sendResponse();
+      } catch (error) {
+        rootLogger.warn('sendResponse failed', error);
+      }
+    });
+  return true;
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  void aggregator.handleTabRemoved(tabId).catch((error) => {
+    rootLogger.error('tab removal handling failed', { tabId, error });
+  });
+});
+
+export async function handleRuntimeMessage(
+  aggregatorRef: BackgroundAggregator,
+  logger: ChromeLogger,
+  message: unknown,
+  sender: chrome.runtime.MessageSender,
+): Promise<void> {
+  if (!message || typeof message !== 'object') {
+    return;
   }
+  const { type } = message as { type?: unknown };
+  if (type === 'TASKS_UPDATE') {
+    try {
+      assertContentScriptTasksUpdate(message);
+    } catch (error) {
+      logger.warn('invalid TASKS_UPDATE payload', error);
+      return;
+    }
+    await aggregatorRef.handleTasksUpdate(message, sender);
+    return;
+  }
+  if (type === 'TASKS_HEARTBEAT') {
+    try {
+      assertContentScriptHeartbeat(message);
+    } catch (error) {
+      logger.warn('invalid TASKS_HEARTBEAT payload', error);
+      return;
+    }
+    await aggregatorRef.handleHeartbeat(message, sender);
+    return;
+  }
+  logger.debug('unknown message type ignored', { type });
 }
 
-chrome.runtime.onInstalled.addListener(() => {
-  bootstrapBackground();
-});  
-  
+function createVerbosityAwareLogger(chromeRef: ChromeLike): { logger: ChromeLogger } {
+  let verbose = false;
+  const consoleLike = {
+    debug: (...args: unknown[]) => {
+      if (verbose) {
+        console.debug(...args);
+      }
+    },
+    info: (...args: unknown[]) => console.info(...args),
+    warn: (...args: unknown[]) => console.warn(...args),
+    error: (...args: unknown[]) => console.error(...args),
+  } satisfies Pick<Console, 'debug' | 'info' | 'warn' | 'error'>;
+  const logger = createLogger('codex-background', consoleLike);
 
+  void refreshVerboseFlag();
+
+  chromeRef.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== 'session') {
+      return;
+    }
+    const change = changes[VERBOSE_KEY];
+    if (!change) {
+      return;
+    }
+    const nextVerbose = Boolean(change.newValue);
+    if (nextVerbose === verbose) {
+      return;
+    }
+    verbose = nextVerbose;
+    logger.info('verbose flag toggled', { verbose });
+  });
+
+  async function refreshVerboseFlag(): Promise<void> {
+    try {
+      const result = await chromeRef.storage.session.get({ [VERBOSE_KEY]: false });
+      const nextVerbose = Boolean(result[VERBOSE_KEY]);
+      if (nextVerbose !== verbose) {
+        verbose = nextVerbose;
+        logger.info('verbose flag toggled', { verbose });
+      }
+    } catch (error) {
+      console.warn('failed to read verbose flag', error);
+    }
+  }
+
+  return { logger };
+}

--- a/extension/src/background/notifications.ts
+++ b/extension/src/background/notifications.ts
@@ -1,15 +1,191 @@
-/**
- * Placeholder for the user-facing notification pipeline.
- *
- * Notification requirements (debounce, RU/EN strings, single-fire when count
- * transitions from >0 to 0) are specified in `spec/system-capabilities.md`,
- * `spec/nfr.md` and `spec/test-plan.md`. The module will be fully implemented
- * in later roadmap phases.
- */
+import type { AggregatedTabsState } from '../shared/contracts';
+import {
+  createChildLogger,
+  createLogger,
+  resolveChrome,
+  type ChromeLike,
+  type ChromeLogger,
+} from '../shared/chrome';
+import type { BackgroundAggregator } from './aggregator';
 
-export function initializeNotifications(): void {
-  if (import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
-    console.debug('[codex-tasks-watcher] notifications placeholder initialized');
+const NOTIFICATION_ID = 'codex-tasks-zero';
+
+interface NotificationStrings {
+  readonly title: string;
+  readonly message: string;
+  readonly buttonOk: string;
+}
+
+const STRINGS: Record<'en' | 'ru', NotificationStrings> = {
+  en: {
+    title: 'Codex',
+    message: 'All Codex tasks are complete',
+    buttonOk: 'OK',
+  },
+  ru: {
+    title: 'Codex',
+    message: 'Все задачи в Codex завершены',
+    buttonOk: 'ОК',
+  },
+};
+
+export interface NotificationsOptions {
+  readonly chrome?: ChromeLike;
+  readonly logger?: ChromeLogger;
+  readonly now?: () => number;
+}
+
+export interface NotificationsController {
+  dispose(): void;
+}
+
+export function initializeNotifications(
+  aggregator: BackgroundAggregator,
+  options: NotificationsOptions = {},
+): NotificationsController {
+  const chrome = options.chrome ?? resolveChrome();
+  const baseLogger = options.logger ?? createLogger('codex-background');
+  const logger = createChildLogger(baseLogger, 'notifications');
+  const now = options.now ?? (() => Date.now());
+  const locale = resolveLocale(chrome);
+  const strings = STRINGS[locale];
+
+  let disposed = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let scheduledTarget = 0;
+  let activeNotificationId: string | undefined;
+
+  const unsubscribe = aggregator.onStateChange((event) => {
+    if (disposed) {
+      return;
+    }
+    handleStateSnapshot(event.current).catch((error) => {
+      logger.error('state change handling failed', error);
+    });
+  });
+
+  void aggregator.ready
+    .then(() => aggregator.getSnapshot())
+    .then((snapshot) => handleStateSnapshot(snapshot))
+    .catch((error) => {
+      logger.error('failed to read initial state', error);
+    });
+
+  return {
+    dispose() {
+      disposed = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      scheduledTarget = 0;
+      unsubscribe();
+    },
+  };
+
+  async function handleStateSnapshot(state: AggregatedTabsState): Promise<void> {
+    if (disposed) {
+      return;
+    }
+    if (state.lastTotal > 0) {
+      cancelTimer();
+      await clearNotification();
+      return;
+    }
+    if (state.debounce.since === 0) {
+      cancelTimer();
+      return;
+    }
+    scheduleTimer(state);
   }
+
+  function scheduleTimer(state: AggregatedTabsState): void {
+    const target = state.debounce.since + state.debounce.ms;
+    const current = now();
+    if (current >= target) {
+      void triggerNotification();
+      return;
+    }
+    if (timer && scheduledTarget === target) {
+      return;
+    }
+    cancelTimer();
+    const delay = Math.max(0, target - current);
+    scheduledTarget = target;
+    timer = setTimeout(() => {
+      timer = undefined;
+      scheduledTarget = 0;
+      void triggerNotification();
+    }, delay);
+    logger.debug('debounce timer scheduled', { delay, target });
+  }
+
+  function cancelTimer(): void {
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+    scheduledTarget = 0;
+  }
+
+  async function triggerNotification(): Promise<void> {
+    if (disposed) {
+      return;
+    }
+    const snapshot = await aggregator.getSnapshot();
+    if (snapshot.debounce.since === 0) {
+      logger.debug('debounce window already cleared');
+      return;
+    }
+    const target = snapshot.debounce.since + snapshot.debounce.ms;
+    const current = now();
+    if (current < target) {
+      logger.debug('debounce window not ready yet');
+      scheduleTimer(snapshot);
+      return;
+    }
+    if (snapshot.lastTotal !== 0 || !allCountsZero(snapshot)) {
+      logger.info('activity detected during debounce, skipping notification');
+      cancelTimer();
+      return;
+    }
+    try {
+      const notificationId = await chrome.notifications.create(NOTIFICATION_ID, {
+        type: 'basic',
+        title: strings.title,
+        message: strings.message,
+        iconUrl: 'assets/icon128.png',
+        buttons: [{ title: strings.buttonOk }],
+      });
+      activeNotificationId = notificationId ?? NOTIFICATION_ID;
+      logger.info('notification created', { notificationId: activeNotificationId });
+    } catch (error) {
+      logger.error('failed to create notification', error);
+    } finally {
+      cancelTimer();
+      await aggregator.clearDebounceIfIdle();
+    }
+  }
+
+  async function clearNotification(): Promise<void> {
+    if (!activeNotificationId) {
+      return;
+    }
+    try {
+      await chrome.notifications.clear(activeNotificationId);
+      logger.debug('notification cleared', { notificationId: activeNotificationId });
+    } catch (error) {
+      logger.warn('failed to clear notification', error);
+    }
+    activeNotificationId = undefined;
+  }
+}
+
+function resolveLocale(chrome: ChromeLike): 'en' | 'ru' {
+  const uiLocale = chrome.i18n?.getUILanguage?.() ?? globalThis.navigator?.language ?? 'en';
+  return uiLocale.toLowerCase().startsWith('ru') ? 'ru' : 'en';
+}
+
+function allCountsZero(state: AggregatedTabsState): boolean {
+  return Object.values(state.tabs).every((tab) => tab.count === 0);
 }

--- a/extension/tests/unit/background/aggregator.test.ts
+++ b/extension/tests/unit/background/aggregator.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import {
+  type ContentScriptHeartbeat,
+  type ContentScriptTasksUpdate,
+} from '../../../src/shared/contracts';
+import {
+  createMockChrome,
+  setChromeInstance,
+  type ChromeMock,
+} from '../../../src/shared/chrome';
+import { getSessionStateKey } from '../../../src/shared/storage';
+import { initializeAggregator } from '../../../src/background/aggregator';
+
+describe('BackgroundAggregator', () => {
+  let chromeMock: ChromeMock;
+
+  beforeEach(() => {
+    chromeMock = createMockChrome();
+    setChromeInstance(chromeMock);
+  });
+
+  afterEach(() => {
+    setChromeInstance(undefined);
+  });
+
+  it('persists TASKS_UPDATE payloads and recalculates totals', async () => {
+    const aggregator = initializeAggregator({ chrome: chromeMock });
+    await aggregator.ready;
+
+    const message: ContentScriptTasksUpdate = {
+      type: 'TASKS_UPDATE',
+      origin: 'https://codex.openai.com/tab',
+      active: true,
+      count: 2,
+      signals: [
+        { detector: 'D2_STOP_BUTTON', evidence: 'Stop button visible', taskKey: 'stop:1' },
+        { detector: 'D1_SPINNER', evidence: 'Spinner detected' },
+      ],
+      ts: 1_000,
+    };
+    const sender = { tab: { id: 7, title: 'Codex – Tasks' } } as chrome.runtime.MessageSender;
+
+    await aggregator.handleTasksUpdate(message, sender);
+    const snapshot = await aggregator.getSnapshot();
+    const tabState = snapshot.tabs['7'];
+    expect(tabState).toBeDefined();
+    expect(tabState.count).toBe(2);
+    expect(tabState.active).toBe(true);
+    expect(tabState.origin).toBe(message.origin);
+    expect(snapshot.lastTotal).toBe(2);
+    expect(snapshot.debounce.since).toBe(0);
+
+    const stored = await chromeMock.storage.session.get(getSessionStateKey());
+    const storedState = stored[getSessionStateKey()] as unknown;
+    expect(storedState).toMatchObject({ lastTotal: 2 });
+  });
+
+  it('resets heartbeat status on TASKS_HEARTBEAT', async () => {
+    let currentTime = 0;
+    const aggregator = initializeAggregator({ chrome: chromeMock, now: () => currentTime });
+    await aggregator.ready;
+
+    const sender = { tab: { id: 3, title: 'Codex' } } as chrome.runtime.MessageSender;
+    const updateMessage: ContentScriptTasksUpdate = {
+      type: 'TASKS_UPDATE',
+      origin: 'https://codex.openai.com/tab',
+      active: false,
+      count: 0,
+      signals: [],
+      ts: 500,
+    };
+    await aggregator.handleTasksUpdate(updateMessage, sender);
+
+    const heartbeat: ContentScriptHeartbeat = {
+      type: 'TASKS_HEARTBEAT',
+      origin: updateMessage.origin,
+      ts: 1_000,
+      lastUpdateTs: 500,
+      intervalMs: 15_000,
+    };
+
+    await aggregator.handleHeartbeat(heartbeat, sender);
+    const snapshot = await aggregator.getSnapshot();
+    expect(snapshot.tabs['3'].heartbeat.status).toBe('OK');
+    expect(snapshot.tabs['3'].heartbeat.lastReceivedAt).toBe(1_000);
+  });
+
+  it('marks tabs as stale after missed heartbeat interval', async () => {
+    let currentTime = 0;
+    const aggregator = initializeAggregator({ chrome: chromeMock, now: () => currentTime });
+    await aggregator.ready;
+
+    const sender = { tab: { id: 11, title: 'Codex' } } as chrome.runtime.MessageSender;
+    const heartbeat: ContentScriptHeartbeat = {
+      type: 'TASKS_HEARTBEAT',
+      origin: 'https://codex.openai.com',
+      ts: 0,
+      lastUpdateTs: 0,
+      intervalMs: 10_000,
+    };
+    await aggregator.handleHeartbeat(heartbeat, sender);
+
+    currentTime = 31_000; // 3 * interval + 1s
+    const stale = await aggregator.evaluateHeartbeatStatuses();
+    expect(stale).toEqual([11]);
+
+    const snapshot = await aggregator.getSnapshot();
+    expect(snapshot.tabs['11'].heartbeat.status).toBe('STALE');
+    expect(snapshot.tabs['11'].heartbeat.missedCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('clears debounce window when state remains idle', async () => {
+    let currentTime = 0;
+    const aggregator = initializeAggregator({ chrome: chromeMock, now: () => currentTime });
+    await aggregator.ready;
+
+    const sender = { tab: { id: 9, title: 'Codex' } } as chrome.runtime.MessageSender;
+    const activeMessage: ContentScriptTasksUpdate = {
+      type: 'TASKS_UPDATE',
+      origin: 'https://codex.openai.com/tab',
+      active: true,
+      count: 1,
+      signals: [],
+      ts: 1_000,
+    };
+    await aggregator.handleTasksUpdate(activeMessage, sender);
+
+    currentTime = 2_000;
+    const idleMessage: ContentScriptTasksUpdate = { ...activeMessage, active: false, count: 0, ts: 2_000 };
+    await aggregator.handleTasksUpdate(idleMessage, sender);
+
+    const preSnapshot = await aggregator.getSnapshot();
+    expect(preSnapshot.debounce.since).toBe(2_000);
+
+    const cleared = await aggregator.clearDebounceIfIdle();
+    expect(cleared).toBe(true);
+    const postSnapshot = await aggregator.getSnapshot();
+    expect(postSnapshot.debounce.since).toBe(0);
+  });
+
+  it('retries storage writes on transient failures', async () => {
+    const originalSet = chromeMock.storage.session.set;
+    let attempt = 0;
+    chromeMock.storage.session.set = async (items) => {
+      attempt += 1;
+      if (attempt < 2) {
+        throw new Error('transient');
+      }
+      return originalSet(items);
+    };
+
+    const aggregator = initializeAggregator({ chrome: chromeMock });
+    await aggregator.ready;
+
+    const message: ContentScriptTasksUpdate = {
+      type: 'TASKS_UPDATE',
+      origin: 'https://codex.openai.com',
+      active: false,
+      count: 0,
+      signals: [],
+      ts: 1_000,
+    };
+    const sender = { tab: { id: 1, title: 'Codex' } } as chrome.runtime.MessageSender;
+
+    await aggregator.handleTasksUpdate(message, sender);
+    expect(attempt).toBe(2);
+  });
+
+  it('restores persisted state after reinitialization', async () => {
+    const aggregator = initializeAggregator({ chrome: chromeMock });
+    await aggregator.ready;
+
+    const message: ContentScriptTasksUpdate = {
+      type: 'TASKS_UPDATE',
+      origin: 'https://codex.openai.com',
+      active: true,
+      count: 3,
+      signals: [],
+      ts: 1_000,
+    };
+    const sender = { tab: { id: 42, title: 'Codex' } } as chrome.runtime.MessageSender;
+    await aggregator.handleTasksUpdate(message, sender);
+
+    const restoredAggregator = initializeAggregator({ chrome: chromeMock });
+    await restoredAggregator.ready;
+    const snapshot = await restoredAggregator.getSnapshot();
+    expect(snapshot.lastTotal).toBe(3);
+    expect(snapshot.tabs['42']).toBeDefined();
+  });
+});

--- a/extension/tests/unit/background/alarms.test.ts
+++ b/extension/tests/unit/background/alarms.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import type { AggregatedTabsState } from '../../../src/shared/contracts';
+import {
+  createMockChrome,
+  setChromeInstance,
+  type ChromeMock,
+} from '../../../src/shared/chrome';
+import type {
+  AggregatorChangeEvent,
+  AggregatorEventReason,
+  BackgroundAggregator,
+} from '../../../src/background/aggregator';
+import { registerAlarms } from '../../../src/background/alarms';
+
+describe('background alarms', () => {
+  let chromeMock: ChromeMock;
+
+  beforeEach(() => {
+    chromeMock = createMockChrome();
+    setChromeInstance(chromeMock);
+  });
+
+  afterEach(() => {
+    setChromeInstance(undefined);
+  });
+
+  it('enforces autoDiscardable=false for tracked tabs', async () => {
+    const state: AggregatedTabsState = {
+      tabs: {
+        '5': {
+          origin: 'https://codex.openai.com',
+          title: 'Codex',
+          count: 1,
+          active: true,
+          updatedAt: 1_000,
+          lastSeenAt: 1_000,
+          heartbeat: {
+            lastReceivedAt: 1_000,
+            expectedIntervalMs: 15_000,
+            status: 'OK',
+            missedCount: 0,
+          },
+          signals: [],
+        },
+      },
+      lastTotal: 1,
+      debounce: { ms: 12_000, since: 0 },
+    };
+
+    const aggregator = createAggregatorStub(state);
+    registerAlarms(aggregator, { chrome: chromeMock });
+
+    await Promise.resolve();
+    expect(chromeMock.tabs.update).toHaveBeenCalledWith(5, { autoDiscardable: false });
+
+    chromeMock.tabs.update.mockClear();
+    state.tabs['6'] = {
+      ...state.tabs['5'],
+      active: false,
+    };
+    emitChange(aggregator, state, 'tasks-update');
+    await Promise.resolve();
+    expect(chromeMock.tabs.update).toHaveBeenCalledWith(6, { autoDiscardable: false });
+  });
+
+  it('pings stale tabs on alarm tick', async () => {
+    const state: AggregatedTabsState = {
+      tabs: {
+        '7': {
+          origin: 'https://codex.openai.com',
+          title: 'Codex',
+          count: 0,
+          active: false,
+          updatedAt: 0,
+          lastSeenAt: 0,
+          heartbeat: {
+            lastReceivedAt: 0,
+            expectedIntervalMs: 15_000,
+            status: 'STALE',
+            missedCount: 1,
+          },
+          signals: [],
+        },
+      },
+      lastTotal: 0,
+      debounce: { ms: 12_000, since: 0 },
+    };
+
+    const aggregator = createAggregatorStub(state);
+    const staleTabs = [7];
+    aggregator.evaluateHeartbeatStatuses = vi.fn(async () => staleTabs);
+    registerAlarms(aggregator, { chrome: chromeMock });
+
+    chromeMock.__events.alarms.onAlarm.emit({ name: 'codex-poll' } as chrome.alarms.Alarm);
+    await Promise.resolve();
+
+    expect(aggregator.evaluateHeartbeatStatuses).toHaveBeenCalled();
+    expect(chromeMock.tabs.sendMessage).toHaveBeenCalledWith(7, { type: 'PING' });
+  });
+});
+
+type AggregatorStub = BackgroundAggregator & {
+  emit: (event: AggregatorChangeEvent) => void;
+};
+
+function createAggregatorStub(initial: AggregatedTabsState): AggregatorStub {
+  let snapshot = initial;
+  const listeners = new Set<(event: AggregatorChangeEvent) => void>();
+  const aggregator: Partial<AggregatorStub> = {
+    ready: Promise.resolve(),
+    onStateChange(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    getSnapshot: vi.fn(async () => snapshot),
+    getTrackedTabIds: vi.fn(async () => Object.keys(snapshot.tabs).map(Number)),
+    handleTasksUpdate: vi.fn(async () => undefined),
+    handleHeartbeat: vi.fn(async () => undefined),
+    handleTabRemoved: vi.fn(async () => undefined),
+    evaluateHeartbeatStatuses: vi.fn(async () => [] as number[]),
+    clearDebounceIfIdle: vi.fn(async () => false),
+    emit(event) {
+      listeners.forEach((listener) => listener(event));
+    },
+  };
+  return aggregator as AggregatorStub;
+}
+
+function emitChange(
+  aggregator: AggregatorStub,
+  state: AggregatedTabsState,
+  reason: AggregatorEventReason,
+): void {
+  const event: AggregatorChangeEvent = {
+    reason,
+    previous: state,
+    current: state,
+  };
+  aggregator.emit(event);
+}

--- a/extension/tests/unit/background/index.test.ts
+++ b/extension/tests/unit/background/index.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  ContentScriptHeartbeat,
+  ContentScriptTasksUpdate,
+} from '../../../src/shared/contracts';
+import type { BackgroundAggregator } from '../../../src/background/aggregator';
+import { handleRuntimeMessage } from '../../../src/background/index';
+
+function createAggregatorMock(): BackgroundAggregator {
+  return {
+    ready: Promise.resolve(),
+    onStateChange: vi.fn(() => () => undefined),
+    getSnapshot: vi.fn(async () => ({ tabs: {}, lastTotal: 0, debounce: { ms: 12_000, since: 0 } })),
+    getTrackedTabIds: vi.fn(async () => []),
+    handleTasksUpdate: vi.fn(async () => undefined),
+    handleHeartbeat: vi.fn(async () => undefined),
+    handleTabRemoved: vi.fn(async () => undefined),
+    evaluateHeartbeatStatuses: vi.fn(async () => []),
+    clearDebounceIfIdle: vi.fn(async () => false),
+  };
+}
+
+function createLoggerMock() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe('background message handler', () => {
+  it('routes TASKS_UPDATE to the aggregator', async () => {
+    const aggregator = createAggregatorMock();
+    const logger = createLoggerMock();
+    const message: ContentScriptTasksUpdate = {
+      type: 'TASKS_UPDATE',
+      origin: 'https://codex.openai.com',
+      active: true,
+      count: 1,
+      signals: [],
+      ts: 100,
+    };
+    const sender = { tab: { id: 1 } } as chrome.runtime.MessageSender;
+
+    await handleRuntimeMessage(aggregator, logger, message, sender);
+    expect(aggregator.handleTasksUpdate).toHaveBeenCalledWith(message, sender);
+  });
+
+  it('routes TASKS_HEARTBEAT to the aggregator', async () => {
+    const aggregator = createAggregatorMock();
+    const logger = createLoggerMock();
+    const message: ContentScriptHeartbeat = {
+      type: 'TASKS_HEARTBEAT',
+      origin: 'https://codex.openai.com',
+      ts: 200,
+      lastUpdateTs: 150,
+      intervalMs: 15_000,
+    };
+    const sender = { tab: { id: 2 } } as chrome.runtime.MessageSender;
+
+    await handleRuntimeMessage(aggregator, logger, message, sender);
+    expect(aggregator.handleHeartbeat).toHaveBeenCalledWith(message, sender);
+  });
+
+  it('ignores invalid payloads', async () => {
+    const aggregator = createAggregatorMock();
+    const logger = createLoggerMock();
+    const badMessage = { type: 'TASKS_UPDATE' };
+    const sender = { tab: { id: 3 } } as chrome.runtime.MessageSender;
+
+    await handleRuntimeMessage(aggregator, logger, badMessage, sender);
+    expect(aggregator.handleTasksUpdate).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/extension/tests/unit/background/notifications.test.ts
+++ b/extension/tests/unit/background/notifications.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import type { ContentScriptTasksUpdate } from '../../../src/shared/contracts';
+import {
+  createMockChrome,
+  setChromeInstance,
+  type ChromeMock,
+} from '../../../src/shared/chrome';
+import { initializeAggregator } from '../../../src/background/aggregator';
+import { initializeNotifications } from '../../../src/background/notifications';
+
+describe('background notifications', () => {
+  let chromeMock: ChromeMock;
+  let currentTime: number;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    chromeMock = createMockChrome();
+    setChromeInstance(chromeMock);
+    currentTime = 0;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    setChromeInstance(undefined);
+  });
+
+  it('creates a notification after the debounce window elapses', async () => {
+    const aggregator = initializeAggregator({ chrome: chromeMock, now: () => currentTime });
+    await aggregator.ready;
+
+    const sender = { tab: { id: 1, title: 'Codex' } } as chrome.runtime.MessageSender;
+    const makeUpdate = (count: number, ts: number): ContentScriptTasksUpdate => ({
+      type: 'TASKS_UPDATE',
+      origin: 'https://codex.openai.com',
+      active: count > 0,
+      count,
+      signals: [],
+      ts,
+    });
+
+    await aggregator.handleTasksUpdate(makeUpdate(1, 1_000), sender);
+    currentTime = 2_000;
+    await aggregator.handleTasksUpdate(makeUpdate(0, 2_000), sender);
+
+    const createSpy = vi.spyOn(chromeMock.notifications, 'create');
+    const controller = initializeNotifications(aggregator, {
+      chrome: chromeMock,
+      now: () => currentTime,
+    });
+
+    currentTime = 14_000;
+    await vi.advanceTimersByTimeAsync(12_000);
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    const snapshot = await aggregator.getSnapshot();
+    expect(snapshot.debounce.since).toBe(0);
+
+    controller.dispose();
+  });
+
+  it('cancels notification timer when activity resumes', async () => {
+    const aggregator = initializeAggregator({ chrome: chromeMock, now: () => currentTime });
+    await aggregator.ready;
+
+    const sender = { tab: { id: 5, title: 'Codex' } } as chrome.runtime.MessageSender;
+    const makeUpdate = (count: number, ts: number): ContentScriptTasksUpdate => ({
+      type: 'TASKS_UPDATE',
+      origin: 'https://codex.openai.com',
+      active: count > 0,
+      count,
+      signals: [],
+      ts,
+    });
+
+    await aggregator.handleTasksUpdate(makeUpdate(1, 500), sender);
+    currentTime = 1_500;
+    await aggregator.handleTasksUpdate(makeUpdate(0, 1_500), sender);
+
+    const createSpy = vi.spyOn(chromeMock.notifications, 'create');
+    const controller = initializeNotifications(aggregator, {
+      chrome: chromeMock,
+      now: () => currentTime,
+    });
+
+    currentTime = 2_000;
+    await aggregator.handleTasksUpdate(makeUpdate(2, 2_000), sender);
+
+    await vi.runOnlyPendingTimersAsync();
+    expect(createSpy).not.toHaveBeenCalled();
+
+    controller.dispose();
+  });
+
+  it('clears existing notifications when tasks become active again', async () => {
+    const aggregator = initializeAggregator({ chrome: chromeMock, now: () => currentTime });
+    await aggregator.ready;
+
+    const sender = { tab: { id: 9, title: 'Codex' } } as chrome.runtime.MessageSender;
+    const makeUpdate = (count: number, ts: number): ContentScriptTasksUpdate => ({
+      type: 'TASKS_UPDATE',
+      origin: 'https://codex.openai.com',
+      active: count > 0,
+      count,
+      signals: [],
+      ts,
+    });
+
+    await aggregator.handleTasksUpdate(makeUpdate(1, 1_000), sender);
+    currentTime = 2_000;
+    await aggregator.handleTasksUpdate(makeUpdate(0, 2_000), sender);
+
+    const createSpy = vi.spyOn(chromeMock.notifications, 'create');
+    const clearSpy = vi.spyOn(chromeMock.notifications, 'clear');
+
+    const controller = initializeNotifications(aggregator, {
+      chrome: chromeMock,
+      now: () => currentTime,
+    });
+
+    currentTime = 14_000;
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(createSpy).toHaveBeenCalledTimes(1);
+
+    currentTime = 15_000;
+    await aggregator.handleTasksUpdate(makeUpdate(3, 15_000), sender);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(clearSpy).toHaveBeenCalled();
+
+    controller.dispose();
+  });
+});


### PR DESCRIPTION
## Summary
- implement a stateful background aggregator that handles TASKS_UPDATE/HEARTBEAT messages, persists AggregatedTabsState with retries, and tracks stale heartbeats
- add notification and alarm controllers to drive localized debounce notifications, maintain autoDiscardable tabs, and send recovery PINGs
- wire the background entry point with verbose logging controls and extend the Chrome mock plus new unit tests for aggregator, alarms, notifications, and message routing

## Testing
- `npm run test:unit` *(fails: vitest not installed and npm install blocked by registry permissions)*

------
https://chatgpt.com/codex/tasks/task_e_68e403d2a76c8332979c45e648caac89