### PR TITLE
Закрытие фазы 3 роадмапа: фоновый сервис и логирование

### DIFF
--- a/extension/tests/unit/background/index.test.ts
+++ b/extension/tests/unit/background/index.test.ts
@@ -1,16 +1,39 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   ContentScriptHeartbeat,
   ContentScriptTasksUpdate,
 } from '../../../src/shared/contracts';
 import type { BackgroundAggregator } from '../../../src/background/aggregator';
-import { handleRuntimeMessage } from '../../../src/background/index';
+import {
+  createMockChrome,
+  setChromeInstance,
+  type ChromeMock,
+} from '../../../src/shared/chrome';
+
+let chromeMock: ChromeMock;
+let handleRuntimeMessage: typeof import('../../../src/background/index')['handleRuntimeMessage'];
+
+beforeEach(async () => {
+  vi.resetModules();
+  chromeMock = createMockChrome();
+  setChromeInstance(chromeMock);
+  ({ handleRuntimeMessage } = await import('../../../src/background/index'));
+});
+
+afterEach(() => {
+  setChromeInstance(undefined);
+  vi.restoreAllMocks();
+});
 
 function createAggregatorMock(): BackgroundAggregator {
   return {
     ready: Promise.resolve(),
     onStateChange: vi.fn(() => () => undefined),
-    getSnapshot: vi.fn(async () => ({ tabs: {}, lastTotal: 0, debounce: { ms: 12_000, since: 0 } })),
+    getSnapshot: vi.fn(async () => ({
+      tabs: {},
+      lastTotal: 0,
+      debounce: { ms: 12_000, since: 0 },
+    })),
     getTrackedTabIds: vi.fn(async () => []),
     handleTasksUpdate: vi.fn(async () => undefined),
     handleHeartbeat: vi.fn(async () => undefined),
@@ -73,4 +96,28 @@ describe('background message handler', () => {
     expect(aggregator.handleTasksUpdate).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalled();
   });
+
+  it('reacts to verbose flag changes stored in session storage', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    await chromeMock.storage.session.set({ 'codex.tasks.verbose': true });
+    expect(hasVerboseLog(infoSpy.mock.calls, true)).toBe(true);
+
+    infoSpy.mockClear();
+    await chromeMock.storage.session.set({ 'codex.tasks.verbose': false });
+    expect(hasVerboseLog(infoSpy.mock.calls, false)).toBe(true);
+  });
 });
+
+function hasVerboseLog(calls: unknown[][], expected: boolean): boolean {
+  return calls.some((call) => {
+    const hasMessage = call.some((arg) => arg === 'verbose flag toggled');
+    const hasPayload = call.some((arg) =>
+      typeof arg === 'object' &&
+      arg !== null &&
+      'verbose' in (arg as Record<string, unknown>) &&
+      (arg as Record<string, unknown>).verbose === expected,
+    );
+    return hasMessage && hasPayload;
+  });
+}

--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -72,25 +72,29 @@
   - [x] Поддерживать fail-safe таймер сканирования DOM (heartbeat): каждые ≤15 секунд формировать `TASKS_HEARTBEAT` по схеме `contracts/dto/content-heartbeat.schema.json` и экспортировать типы через `shared/contracts`.
   - [x] Логировать ключевые события (инициализация, heartbeat, ошибки отправки) и учитывать verbose-флаг из `chrome.storage.session`.
 
-## Фаза 3. Background service worker ⏳ (v0.1.0)
+## Фаза 3. Background service worker ✅ (v0.1.0)
 
-- [ ] **Каркас service worker**
-  - [ ] Создать точку входа `src/background/index.ts` с регистрацией listeners (`runtime`, `tabs`, `alarms`, `storage`).
-  - [ ] Организовать маршрутизацию сообщений через единый диспетчер (`handleMessage`) и покрыть happy path + ошибки `runtime.lastError` unit-тестами.
-- [ ] **Агрегатор состояния и хранение**
-  - [ ] Реализовать `aggregator.ts` для обработки `TASKS_UPDATE` и `TASKS_HEARTBEAT`, поддержки нескольких вкладок и обновления `chrome.storage.session` по схеме `contracts/state/aggregated-state.schema.json` (см. `AggregatedTabsState`).
-  - [ ] Добавить retry-механику записи состояния (до 3 попыток с интервалом ~1 c) и логировать неудачи.
-  - [ ] Синхронизировать heartbeat и `lastSeenAt` вкладок, переводить `heartbeat.status` в `STALE` при пропусках и покрыть рестарт service worker тестами.
-- [ ] **Уведомления, i18n и логирование**
-  - [ ] Реализовать `notifications.ts` с антидребезгом и локализованными строками (RU/EN) через общий i18n-слой.
-  - [ ] Инкапсулировать одиночное уведомление при переходе `totalActiveCount` > 0 → 0 и очистку при новых задачах.
-  - [ ] Управлять verbose-логированием: читать флаг из `chrome.storage.session`, переключать уровень и покрыть адаптер тестами.
-- [ ] **Алгоритмы будильников и устойчивость**
-  - [ ] Реализовать `alarms.ts` с расписанием `chrome.alarms`, поддержкой повторных `PING` и восстановлением после sleep.
-  - [ ] Применять `autoDiscardableOff` для вкладок Codex, документировать side-effects и проверять сценарии alarm → message → state.
-- [ ] **Наблюдаемость и телеметрия**
-  - [ ] Логировать ключевые события: `TASKS_UPDATE`, запуск/завершение уведомлений, ошибки чтения/записи `storage.session`, пропуски heartbeat, применение `autoDiscardableOff`.
-  - [ ] Покрыть logging-адаптер тестами на чтение/обновление флага, фильтрацию verbose-событий и fallback при `chrome.runtime.lastError`.
+- [x] **Каркас service worker**
+  - [x] Создать точку входа `src/background/index.ts` с регистрацией listeners (`runtime`, `tabs`, `alarms`, `storage`).
+  - [x] Организовать маршрутизацию сообщений через единый диспетчер (`handleMessage`) и покрыть happy path + ошибки `runtime.lastError` unit-тестами.
+- [x] **Агрегатор состояния и хранение**
+  - [x] Реализовать `aggregator.ts` для обработки `TASKS_UPDATE` и `TASKS_HEARTBEAT`, поддержки нескольких вкладок и обновления `chrome.storage.session` по схеме `contracts/state/aggregated-state.schema.json`
+    (см. `AggregatedTabsState`).
+  - [x] Добавить retry-механику записи состояния (до 3 попыток с интервалом ~1 c) и логировать неудачи.
+  - [x] Синхронизировать heartbeat и `lastSeenAt` вкладок, переводить `heartbeat.status` в `STALE` при пропусках и покрыть рестарт service worker тестами.
+- [x] **Уведомления, i18n и логирование**
+  - [x] Реализовать `notifications.ts` с антидребезгом и локализованными строками (RU/EN) через общий i18n-слой.
+  - [x] Инкапсулировать одиночное уведомление при переходе `totalActiveCount` > 0 → 0 и очистку при новых задачах.
+  - [x] Управлять verbose-логированием: читать флаг из `chrome.storage.session`, переключать уровень и покрыть адаптер тестами.
+- [x] **Алгоритмы будильников и устойчивость**
+  - [x] Реализовать `alarms.ts` с расписанием `chrome.alarms`, поддержкой повторных `PING` и восстановлением после sleep.
+  - [x] Применять `autoDiscardableOff` для вкладок Codex, документировать side-effects и проверять сценарии
+    alarm → message → state.
+- [x] **Наблюдаемость и телеметрия**
+  - [x] Логировать ключевые события: `TASKS_UPDATE`, запуск/завершение уведомлений, ошибки чтения/записи `storage.session`,
+    пропуски heartbeat, применение `autoDiscardableOff`.
+  - [x] Покрыть logging-адаптер тестами на чтение/обновление флага, фильтрацию verbose-событий и fallback при
+    `chrome.runtime.lastError`.
 
 ## Фаза 4. Popup UI ⏳ (v0.1.0)
 


### PR DESCRIPTION
## Описание
- отметила завершение всех подпунктов фазы 3 в `spec/roadmap.md`
- переработала unit-тест `background/index.test.ts`, добавив подготовку моков Chrome перед импортом фонового модуля
- добавила проверку реакции фонового скрипта на переключение verbose-флага в `chrome.storage.session`

## Ссылки
- `spec/roadmap.md`

## Тесты
- не запускались: `npm run test:unit` (npm registry недоступен из окружения)


------
https://chatgpt.com/codex/tasks/task_e_68e40b5136e88332a4fef2de27f1b8ce