### PR TITLE
Fix Ajv schema registration for extension

### DIFF
--- a/extension/src/shared/contracts.ts
+++ b/extension/src/shared/contracts.ts
@@ -4,7 +4,7 @@
  * Скрипт генерации: scripts/generate-contracts.mjs
  */
 
-import Ajv, { type ErrorObject, type ValidateFunction } from 'ajv';
+import Ajv, { type ErrorObject, type ValidateFunction } from 'ajv/dist/2020';
 import addFormats from 'ajv-formats';
 
 export interface ContractDescriptor<T> {
@@ -32,6 +32,7 @@ function createAjv(): Ajv {
     allowUnionTypes: true,
   });
   addFormats(ajv);
+  registerSchemas(ajv);
   return ajv;
 }
 
@@ -44,6 +45,7 @@ function getAjv(): Ajv {
 
 export function resetContractValidationState(): void {
   ajvInstance = undefined;
+  schemasRegistered = false;
   validateContentScriptHeartbeatFn = undefined;
   validateContentScriptTasksUpdateFn = undefined;
   validatePopupRenderStateFn = undefined;
@@ -483,6 +485,26 @@ export const codexTasksUserSettingsSchema = {
     },
   },
 } as const;
+
+const allSchemas = [
+  contentScriptHeartbeatSchema,
+  contentScriptTasksUpdateSchema,
+  popupRenderStateSchema,
+  aggregatedTabsStateSchema,
+  codexTasksUserSettingsSchema,
+] as const;
+
+let schemasRegistered = false;
+
+function registerSchemas(ajv: Ajv): void {
+  if (schemasRegistered) {
+    return;
+  }
+  for (const schema of allSchemas) {
+    ajv.addSchema(schema);
+  }
+  schemasRegistered = true;
+}
 
 let validateContentScriptHeartbeatFn: ValidateFunction<ContentScriptHeartbeat> | undefined;
 export function validateContentScriptHeartbeat(value: unknown): value is ContentScriptHeartbeat {

--- a/scripts/generate-contracts.mjs
+++ b/scripts/generate-contracts.mjs
@@ -18,16 +18,17 @@ async function main() {
 
   const sortedSchemas = schemaFiles.sort((a, b) => a.localeCompare(b));
 
-  const typeChunks: string[] = [];
-  const schemaChunks: string[] = [];
-  const validatorChunks: string[] = [];
-  const resetAssignments: string[] = [];
-  const registryEntries: string[] = [];
+  const typeChunks = [];
+  const schemaChunks = [];
+  const schemaVarNames = [];
+  const validatorChunks = [];
+  const resetAssignments = [];
+  const registryEntries = [];
 
   for (const schemaPath of sortedSchemas) {
     const schemaContent = await fs.readFile(schemaPath, 'utf-8');
     const schemaJson = JSON.parse(schemaContent);
-    const typeName: string | undefined = schemaJson.title;
+    const typeName = schemaJson.title;
     if (!typeName || typeof typeName !== 'string') {
       throw new Error(`Схема ${schemaPath} не содержит строкового поля title`);
     }
@@ -49,6 +50,7 @@ async function main() {
     const assertFunctionName = `assert${typeName}`;
 
     schemaChunks.push(`export const ${schemaVarName} = ${schemaContent.trim()} as const;\n`);
+    schemaVarNames.push(schemaVarName);
 
     validatorChunks.push(`let ${validatorVarName}: ValidateFunction<${typeName}> | undefined;\n`);
     validatorChunks.push(`export function ${validateFunctionName}(value: unknown): value is ${typeName} {\n`);
@@ -59,7 +61,9 @@ async function main() {
     validatorChunks.push('}\n');
     validatorChunks.push(`export function ${assertFunctionName}(value: unknown): asserts value is ${typeName} {\n`);
     validatorChunks.push(`  if (!${validateFunctionName}(value)) {\n`);
-    validatorChunks.push(`    throw new ContractValidationError('${typeName}', ${validatorVarName}?.errors ?? []);\n`);
+    validatorChunks.push(
+      `    throw new ContractValidationError('${typeName}', ${validatorVarName}?.errors ?? []);\n`,
+    );
     validatorChunks.push('  }\n');
     validatorChunks.push('}\n');
 
@@ -69,14 +73,17 @@ async function main() {
     );
   }
 
-  const fileContent = `/* eslint-disable */\n/**\n * Автогенерируемый модуль. Не редактируйте вручную.\n * Скрипт генерации: scripts/generate-contracts.mjs\n */\n\nimport Ajv, { type ErrorObject, type ValidateFunction } from 'ajv';\nimport addFormats from 'ajv-formats';\n\nexport interface ContractDescriptor<T> {\n  readonly schema: unknown;\n  readonly validate: (value: unknown) => value is T;\n  readonly assert: (value: unknown) => asserts value is T;\n}\n\nexport class ContractValidationError extends Error {\n  public readonly errors: ErrorObject[];\n\n  constructor(public readonly typeName: string, errors: ErrorObject[] = []) {\n    super(\`Validation failed for contract "\${typeName}"\`);\n    this.name = 'ContractValidationError';\n    this.errors = errors;\n  }\n}\n\nlet ajvInstance: Ajv | undefined;\n\nfunction createAjv(): Ajv {\n  const ajv = new Ajv({\n    strict: true,\n    allErrors: true,\n    allowUnionTypes: true,\n  });\n  addFormats(ajv);\n  return ajv;\n}\n\nfunction getAjv(): Ajv {\n  if (!ajvInstance) {\n    ajvInstance = createAjv();\n  }\n  return ajvInstance;\n}\n\nexport function resetContractValidationState(): void {\n  ajvInstance = undefined;\n${resetAssignments.join('\n')}\n}\n\n${typeChunks.join('\n')}\n${schemaChunks.join('\n')}\n${validatorChunks.join('\n')}\nexport const contractRegistry = {\n${registryEntries.join('\n')}\n} as const;\n\ntype ExtractAssertedType<T> = T extends (value: unknown) => asserts value is infer R ? R : never;\nexport type ContractType = keyof typeof contractRegistry;\n\nexport function getContractDescriptor<T extends ContractType>(type: T): ContractDescriptor<ExtractAssertedType<(typeof contractRegistry)[T]['assert']>> {\n  return contractRegistry[type] as ContractDescriptor<ExtractAssertedType<(typeof contractRegistry)[T]['assert']>>;\n}\n`;
+  const schemaArray = `const allSchemas = [${schemaVarNames.join(', ')}] as const;`;
+  const registerHelper = `let schemasRegistered = false;\n\nfunction registerSchemas(ajv: Ajv): void {\n  if (schemasRegistered) {\n    return;\n  }\n  for (const schema of allSchemas) {\n    ajv.addSchema(schema);\n  }\n  schemasRegistered = true;\n}`;
+
+  const fileContent = `/* eslint-disable */\n/**\n * Автогенерируемый модуль. Не редактируйте вручную.\n * Скрипт генерации: scripts/generate-contracts.mjs\n */\n\nimport Ajv, { type ErrorObject, type ValidateFunction } from 'ajv/dist/2020';\nimport addFormats from 'ajv-formats';\n\nexport interface ContractDescriptor<T> {\n  readonly schema: unknown;\n  readonly validate: (value: unknown) => value is T;\n  readonly assert: (value: unknown) => asserts value is T;\n}\n\nexport class ContractValidationError extends Error {\n  public readonly errors: ErrorObject[];\n\n  constructor(public readonly typeName: string, errors: ErrorObject[] = []) {\n    super(\`Validation failed for contract "\${typeName}"\`);\n    this.name = 'ContractValidationError';\n    this.errors = errors;\n  }\n}\n\nlet ajvInstance: Ajv | undefined;\n\nfunction createAjv(): Ajv {\n  const ajv = new Ajv({\n    strict: true,\n    allErrors: true,\n    allowUnionTypes: true,\n  });\n  addFormats(ajv);\n  registerSchemas(ajv);\n  return ajv;\n}\n\nfunction getAjv(): Ajv {\n  if (!ajvInstance) {\n    ajvInstance = createAjv();\n  }\n  return ajvInstance;\n}\n\nexport function resetContractValidationState(): void {\n  ajvInstance = undefined;\n${resetAssignments.join('\n')}\n}\n\n${typeChunks.join('\n')}\n${schemaChunks.join('\n')}\n${schemaArray}\n\n${registerHelper}\n\n${validatorChunks.join('\n')}\nexport const contractRegistry = {\n${registryEntries.join('\n')}\n} as const;\n\ntype ExtractAssertedType<T> = T extends (value: unknown) => asserts value is infer R ? R : never;\nexport type ContractType = keyof typeof contractRegistry;\n\nexport function getContractDescriptor<T extends ContractType>(type: T): ContractDescriptor<ExtractAssertedType<(typeof contractRegistry)[T]['assert']>> {\n  return contractRegistry[type] as ContractDescriptor<ExtractAssertedType<(typeof contractRegistry)[T]['assert']>>;\n}\n`;
 
   await fs.writeFile(outputFile, fileContent, 'utf-8');
 }
 
-async function collectSchemaFiles(dir: string): Promise<string[]> {
+async function collectSchemaFiles(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
-  const files: string[] = [];
+  const files = [];
   for (const entry of entries) {
     if (entry.isDirectory()) {
       const nested = await collectSchemaFiles(path.join(dir, entry.name));
@@ -88,7 +95,7 @@ async function collectSchemaFiles(dir: string): Promise<string[]> {
   return files;
 }
 
-function toSchemaConstName(typeName: string): string {
+function toSchemaConstName(typeName) {
   return `${typeName.charAt(0).toLowerCase()}${typeName.slice(1)}Schema`;
 }
 


### PR DESCRIPTION
## Summary
- switch the generated contract helpers to Ajv 2020 and register all Codex schemas up front so `$ref` links resolve inside the extension
- reset the cached schema registration together with the Ajv instance when validation state is cleared
- update the generator script to emit the new Ajv bootstrap code and the shared schema registration helper

## Testing
- npm run test:unit *(fails: `vitest` is unavailable because npm install cannot finish in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e43e592e888332911ffe7d86f915ac